### PR TITLE
docs: fix markdown syntax

### DIFF
--- a/doc/supported-language.md
+++ b/doc/supported-language.md
@@ -7,7 +7,7 @@ To date, only a (small) subset of the JavaScript language is supported in Microv
 Note: the most up-to-date authority on supported features is the [set of test scripts](../test/end-to-end/tests), each file of which is a stand-alone Microvium script that exercises a series of features in the language.
 
  - Basic control flow statements (`if`/`else`, `while`, `do..while`, `for`)
- - Primitive operators (`+`, `-`, `/`, `%`, `*`, `**`, `&`, `|`, `>>`, `>>>`, `<<`, `^`, `===`, `!==`, `>`, `<`, `>=`, `<=`, `!`, `~`, `? :`, ``typeof`)
+ - Primitive operators (`+`, `-`, `/`, `%`, `*`, `**`, `&`, `|`, `>>`, `>>>`, `<<`, `^`, `===`, `!==`, `>`, `<`, `>=`, `<=`, `!`, `~`, `? :`, `typeof`)
  - Variable declarations: `var`, `let`, and `const`
  - Nested functions (closures) and function/arrow expressions
  - Dynamically-sized arrays and objects (with limitations, see the next section), computed properties (`o[p]`).


### PR DESCRIPTION
Remove a extra backtick.