### PR TITLE
Fix use of context malloc in VM creation.

### DIFF
--- a/dist-c/microvium.c
+++ b/dist-c/microvium.c
@@ -4125,7 +4125,7 @@ TeError mvm_restore(mvm_VM** result, MVM_LONG_PTR_TYPE lpBytecode, size_t byteco
   size_t allocationSize = sizeof(mvm_VM) +
     sizeof(mvm_TfHostFunction) * importCount +  // Import table
     globalsSize; // Globals
-  vm = (VM*)vm_malloc(vm, allocationSize);
+  vm = (VM*)MVM_CONTEXTUAL_MALLOC(allocationSize, context);
   if (!vm) {
     CODE_COVERAGE_ERROR_PATH(139); // Not hit
     err = MVM_E_MALLOC_FAIL;

--- a/native-vm/microvium.c
+++ b/native-vm/microvium.c
@@ -2610,7 +2610,7 @@ TeError mvm_restore(mvm_VM** result, MVM_LONG_PTR_TYPE lpBytecode, size_t byteco
   size_t allocationSize = sizeof(mvm_VM) +
     sizeof(mvm_TfHostFunction) * importCount +  // Import table
     globalsSize; // Globals
-  vm = (VM*)vm_malloc(vm, allocationSize);
+  vm = (VM*)MVM_CONTEXTUAL_MALLOC(allocationSize, context);
   if (!vm) {
     CODE_COVERAGE_ERROR_PATH(139); // Not hit
     err = MVM_E_MALLOC_FAIL;

--- a/test/getting-started/code/microvium/microvium.c
+++ b/test/getting-started/code/microvium/microvium.c
@@ -4125,7 +4125,7 @@ TeError mvm_restore(mvm_VM** result, MVM_LONG_PTR_TYPE lpBytecode, size_t byteco
   size_t allocationSize = sizeof(mvm_VM) +
     sizeof(mvm_TfHostFunction) * importCount +  // Import table
     globalsSize; // Globals
-  vm = (VM*)vm_malloc(vm, allocationSize);
+  vm = (VM*)MVM_CONTEXTUAL_MALLOC(allocationSize, context);
   if (!vm) {
     CODE_COVERAGE_ERROR_PATH(139); // Not hit
     err = MVM_E_MALLOC_FAIL;


### PR DESCRIPTION
The first malloc call that allocates the VM structure was passed a null VM and so crashed on attempting to access is context field.  This is hidden in uses that don't use the context malloc because the compiler will remove the dead load.