### PR TITLE
Add hooks for setting bounds and permissions on exported pointers.

### DIFF
--- a/native-vm/microvium_internals.h
+++ b/native-vm/microvium_internals.h
@@ -229,6 +229,18 @@ typedef mvm_TeError TeError;
 #define MVM_SNPRINTF snprintf
 #endif
 
+#ifndef MVM_INT32TOSTRING
+#define MVM_INT32TOSTRING(buffer, i) MVM_SNPRINTF(buffer, 12, "%" PRId32, i);
+#endif
+
+#ifndef MVM_POINTER_SET_BOUNDS
+#define MVM_POINTER_SET_BOUNDS(ptr, bounds) ptr
+#endif
+
+#ifndef MVM_POINTER_MAKE_IMMUTABLE
+#define MVM_POINTER_MAKE_IMMUTABLE(ptr) ptr
+#endif
+
 #ifndef MVM_MALLOC
 #define MVM_MALLOC malloc
 #endif


### PR DESCRIPTION
On a CHERI system, the pointers into the Microvium heap give full read-write access to the entire heap.  This means that bounds errors (or passing string pointers to functions that try to mutate their arguments) will corrupt VM state.

The two hooks are:

 - Apply bounds to this pointer.
 - Remove the ability to load pointers or store through the pointer.

Both of these default to doing nothing, but no CHERI platforms they can be a csetbounds / candperms instruction.